### PR TITLE
[APP-1389] added refdocblitz esrally track

### DIFF
--- a/refdocblitz/challenges/default.json
+++ b/refdocblitz/challenges/default.json
@@ -1,0 +1,225 @@
+{
+      "name": "append-no-conflicts",
+      "description": "Indexes the whole reference document corpus using Ascent Customer Platform Elasticsearch production settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only. After that a couple of queries are run.",      "default": true,
+      "schedule": [
+        {
+          "operation": {
+            "operation-type": "put-settings",
+            "body": {
+              "transient": {
+                  "search.default_search_timeout": "{{default_search_timeout | default(-1)}}"
+              }
+            }
+          }
+        },
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "reference_documents_blitz",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index-append",
+          "warmup-time-period": 0,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "default",
+          "clients": 1,
+          "warmup-iterations": 500,
+          "iterations": 200,
+          "target-throughput": 20
+        },
+        {
+          "operation": "term",
+          "clients": 1,
+          "warmup-iterations": 500,
+          "iterations": 200,
+          "target-throughput": 20
+        },
+        {
+          "operation": "phrase",
+          "clients": 1,
+          "warmup-iterations": 500,
+          "iterations": 200,
+          "target-throughput": 20
+        },
+        {
+          "operation": "scroll",
+          "clients": 1,
+          "warmup-iterations": 50,
+          "iterations": 100,
+          "target-throughput": 0.5
+        }
+      ]
+    },
+    {
+      "name": "append-no-conflicts-index-only",
+      "description": "Indexes the whole reference document corpus using Ascent Customer Platform Elasticsearch production settings. We only adjust the number of replicas as we benchmark a single node cluster and Rally will only start the benchmark if the cluster turns green. Document ids are unique so all index operations are append only.",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {{index_settings | default({}) | tojson}}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "reference_documents_blitz",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index-append",
+          "warmup-time-period": 0,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        }
+      ]
+    },
+    {
+      "name": "append-sorted-no-conflicts",
+      "description": "Indexes the whole reference document corpus in an index sorted by timestamp field in descending order (most recent first). Document ids are unique so all index operations are append only.",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
+              "index.sort.field": "timestamp",
+              "index.sort.order": "desc"
+            }{%- endif %}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "reference_documents_blitz",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index-append",
+          "warmup-time-period": 0,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        }
+      ]
+    },
+    {
+      "name": "append-fast-with-conflicts",
+      "description": "Indexes the whole document corpus using a setup that will lead to a larger indexing throughput than the default settings. Rally will produce duplicate ids in 25% of all documents (not configurable) so we can simulate a scenario with appends most of the time and some updates in between.",
+      "schedule": [
+        {
+          "operation": "delete-index"
+        },
+        {
+          "operation": {
+            "operation-type": "create-index",
+            "settings": {%- if index_settings is defined %} {{index_settings | tojson}} {%- else %} {
+              "index.refresh_interval": "30s",
+              "index.number_of_shards": {{number_of_shards | default(6)}},
+              "index.translog.flush_threshold_size": "4g"
+            }{%- endif %}
+          }
+        },
+        {
+          "name": "check-cluster-health",
+          "operation": {
+            "operation-type": "cluster-health",
+            "index": "reference_documents_blitz",
+            "request-params": {
+              "wait_for_status": "{{cluster_health | default('green')}}",
+              "wait_for_no_relocating_shards": "true"
+            }
+          }
+        },
+        {
+          "operation": "index-update",
+          "warmup-time-period": 0,
+          "clients": {{bulk_indexing_clients | default(8)}}
+        },
+        {
+          "name": "refresh-after-index",
+          "operation": "refresh",
+          "clients": 1
+        },
+        {
+          "operation": "force-merge",
+          "clients": 1
+        },
+        {
+          "name": "refresh-after-force-merge",
+          "operation": "refresh",
+          "clients": 1
+        }
+      ]
+    }

--- a/refdocblitz/files.txt
+++ b/refdocblitz/files.txt
@@ -1,0 +1,2 @@
+documents700k.json.gz
+documents-1k.json.bz2

--- a/refdocblitz/index.json
+++ b/refdocblitz/index.json
@@ -1,0 +1,152 @@
+{
+  "settings": {
+    "index.number_of_shards": 1,
+    "index.number_of_replicas": 1,
+    "index.requests.cache.enable": false
+  },
+  "mappings": {
+    "_doc": {
+      "_source": {
+        "excludes": ["data"]
+      },
+      "properties": {
+        "ascent_module_ids": {
+          "type": "keyword"
+        },
+        "attachment": {
+          "properties": {
+            "author": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "content": {
+              "type": "text",
+              "store": true,
+              "term_vector": "with_positions_offsets",
+              "fielddata": true
+            },
+            "content_length": {
+              "type": "integer",
+              "store": true
+            },
+            "content_type": {
+              "type": "text",
+              "store": true,
+              "fielddata": true
+            },
+            "date": {
+              "type": "date"
+            },
+            "language": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "title": {
+              "type": "text",
+              "store": true,
+              "fielddata": true
+            }
+          }
+        },
+        "auto_approval_time": {
+          "type": "date"
+        },
+        "data": {
+          "type": "text",
+          "fielddata": true
+        },
+        "defendant": {
+          "type": "text",
+          "fielddata": true
+        },
+        "document_source_ids": {
+          "type": "integer"
+        },
+        "document_source_names": {
+          "type": "text",
+          "fields": {
+            "raw": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_sort_normalizer"
+            }
+          },
+          "fielddata": true
+        },
+        "document_source_reg_names": {
+          "type": "text",
+          "fields": {
+            "raw": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_sort_normalizer"
+            }
+          },
+          "fielddata": true
+        },
+        "document_type": {
+          "type": "text",
+          "fielddata": true
+        },
+        "filename": {
+          "type": "text",
+          "fielddata": true
+        },
+        "id": {
+          "type": "integer"
+        },
+        "issuing_regulator_ids": {
+          "type": "keyword"
+        },
+        "number": {
+          "type": "text",
+          "fielddata": true
+        },
+        "published_on": {
+          "type": "date"
+        },
+        "regulator_ids": {
+          "type": "keyword"
+        },
+        "rule_full_titles": {
+          "type": "text",
+          "fields": {
+            "raw": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_sort_normalizer"
+            }
+          },
+          "fielddata": true
+        },
+        "rule_ids": {
+          "type": "keyword"
+        },
+        "subject_ids": {
+          "type": "keyword"
+        },
+        "title": {
+          "type": "text",
+          "fields": {
+            "raw": {
+              "type": "keyword",
+              "normalizer": "case_insensitive_sort_normalizer"
+            }
+          },
+          "fielddata": true
+        },
+        "visibility": {
+          "type": "text",
+          "fielddata": true
+        }
+      }
+    }
+  }
+}

--- a/refdocblitz/operations/default.json
+++ b/refdocblitz/operations/default.json
@@ -1,0 +1,58 @@
+{
+  "name": "index-append",
+  "operation-type": "bulk",
+  "bulk-size": {{bulk_size | default(500)}},
+  "ingest-percentage": {{ingest_percentage | default(100)}}
+},
+{
+  "name": "index-update",
+  "operation-type": "bulk",
+  "bulk-size": {{bulk_size | default(500)}},
+  "ingest-percentage": {{ingest_percentage | default(100)}},
+  "conflicts": "{{conflicts | default('random')}}",
+  "on-conflict": "{{on_conflict | default('index')}}",
+  "conflict-probability": {{conflict_probability | default(25)}},
+  "recency": {{recency | default(0)}}
+},
+{
+  "name": "default",
+  "operation-type": "search",
+  "body": {
+    "query": {
+      "match_all": {}
+    }
+  }
+},
+{
+  "name": "term",
+  "operation-type": "search",
+  "body": {
+    "query": {
+      "term": {
+        "body": "control"
+      }
+    }
+  }
+},
+{
+  "name": "phrase",
+  "operation-type": "search",
+  "body": {
+    "query": {
+      "match_phrase": {
+        "body": "control and diversities"
+      }
+    }
+  }
+},
+{
+  "name": "scroll",
+  "operation-type": "search",
+  "pages": 25,
+  "results-per-page": 100,
+  "body": {
+    "query": {
+      "match_all": {}
+    }
+  }
+}

--- a/refdocblitz/track.json
+++ b/refdocblitz/track.json
@@ -1,0 +1,35 @@
+{% import "rally.helpers" as rally with context %}
+
+{
+  "version": 2,
+  "description": "Ascent Technologies Full text benchmark with 500 regulators regulatory documents",
+  "indices": [
+    {
+      "name": "reference_documents_blitz.benchmark.ingest",
+      "body": "index.json",
+      "types": [ "_doc" ]
+    }
+  ],
+  "corpora": [
+    {
+      "name": "refdocblitz",
+      "base-url": "https://ascent-mvp-development.s3-us-west-2.amazonaws.com/APP-1389",
+      "target-type": "_doc",
+      "documents": [
+        {
+          "target-index": "reference_documents_blitz.benchmark.ingest700k",
+          "source-file": "documents700k.json.gz",
+          "document-count": 700000,
+          "compressed-bytes": 23256051757,
+          "uncompressed-bytes": 650306782
+        }
+      ]
+    }
+  ],
+  "operations": [
+    {{ rally.collect(parts="operations/*.json") }}
+  ],
+  "challenges": [
+    {{ rally.collect(parts="challenges/*.json") }}
+  ]
+}

--- a/refdocblitz/track.py
+++ b/refdocblitz/track.py
@@ -1,0 +1,10 @@
+def put_settings(es, params):
+    es.cluster.put_settings(body=params["body"])
+
+
+def register(registry):
+    # register a fallback for older Rally versions
+    try:
+        from esrally.driver.runner import PutSettings
+    except ImportError:
+        registry.register_runner("put-settings", put_settings)


### PR DESCRIPTION
ESRally Track for Ref Doc load test and benchmarking

To Test


* Install ESRally using this [guide](https://esrally.readthedocs.io/en/stable/install.html)

* Run the refdocblitz race
```
esrally race --pipeline=benchmark-only --track=refdocblitz --elasticsearch-plugins="ingest-attachment" --target-hosts=https://a5aace2509174018a4ce8d51ffd358c1.us-east-1.aws.found.io:9243 --client-options="use_ssl:true,verify_certs:true,basic_auth_user:'xxxxx',basic_auth_password:'xxxx'"
```
* We are testing with 700k reference_documents uploaded [here](https://ascent-mvp-development.s3-us-west-2.amazonaws.com/APP-1389/documents700k.json.gz)

**Caveat**
Get the `ascent-mvp-staging` ES credential